### PR TITLE
PickerをEnumで管理する

### DIFF
--- a/SwiftUI_Playground/Sources/Views/HomeView.swift
+++ b/SwiftUI_Playground/Sources/Views/HomeView.swift
@@ -7,15 +7,38 @@
 
 import SwiftUI
 
-struct HomeView: View {
-    var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundColor(.accentColor)
-            Text("Hello, world!")
+enum AutoJoinHotspotOption: CaseIterable, Identifiable, CustomStringConvertible {
+    case never
+    case askToJoin
+    case automatic
+
+    var id: AutoJoinHotspotOption {
+        self
+    }
+
+    var description: String {
+        switch self {
+        case .never:
+            return "Never"
+        case .askToJoin:
+            return "Ask to Join"
+        case .automatic:
+            return "Automatic"
         }
-        .padding()
+    }
+}
+
+struct HomeView: View {
+    @State private var selectedOption: AutoJoinHotspotOption = .never
+
+    var body: some View {
+        Picker("Auto-Join Hotspot", selection: $selectedOption) {
+            ForEach(AutoJoinHotspotOption.allCases) { option in
+                Text(String(describing: option))
+                    .font(.custom(FontFamily.Caprasimo.regular, size: 32))
+            }
+        }
+        .pickerStyle(.wheel)
     }
 }
 


### PR DESCRIPTION
### ブランチ
`feature/picker_with_enum`

### スクリーンショット
<img width="402" alt="Screenshot 2023-07-05 at 15 28 10" src="https://github.com/Masaya1582/SwiftUI_Playground/assets/74645651/89643ebe-4889-4101-9232-b8092771778c">
