### PR TITLE
ListのSeparatorカラーを指定する

### DIFF
--- a/SwiftUI_Playground/Sources/Views/HomeView.swift
+++ b/SwiftUI_Playground/Sources/Views/HomeView.swift
@@ -9,13 +9,15 @@ import SwiftUI
 
 struct HomeView: View {
     var body: some View {
-        VStack {
-            Text("Dio")
-                .font(.custom(FontFamily.Caprasimo.regular, size: 42))
-            Asset.Assets.imgDio.swiftUIImage
-                .resizable()
-                .frame(width: 320, height: 280)
-            Spacer().frame(height: 100)
+        NavigationView {
+            List(0..<10) { i in
+                Text("Row \(i.description)")
+                    .font(.custom(FontFamily.Caprasimo.regular, size: 20))
+                    .listRowSeparatorTint(.red)
+                    // .listRowSeparatorTint(.pink, edges: .top)
+
+            }
+            .navigationTitle("List")
         }
     }
 }


### PR DESCRIPTION
### ブランチ
`feature/list_separator_color`

### スクリーンショット
<img width="402" alt="Screenshot 2023-07-10 at 14 22 00" src="https://github.com/Masaya1582/SwiftUI_Playground/assets/74645651/43d7f903-0e87-4298-8361-88b328a95b6b">
