### PR TITLE
カスタムフォントのチートシート

### DIFF
--- a/SwiftUI_Playground/Sources/Views/HomeView.swift
+++ b/SwiftUI_Playground/Sources/Views/HomeView.swift
@@ -9,13 +9,92 @@ import SwiftUI
 
 struct HomeView: View {
     var body: some View {
-        VStack {
-            Text("Dio")
-                .font(.custom(FontFamily.Caprasimo.regular, size: 42))
-            Asset.Assets.imgDio.swiftUIImage
-                .resizable()
-                .frame(width: 320, height: 280)
-            Spacer().frame(height: 100)
+        HStack {
+            VStack {
+                Text("Large Title")
+                    .font(.largeTitle)
+                Text("Title 1")
+                    .font(.title)
+                Text("Title 2")
+                    .font(.title2)
+                Text("Title 3")
+                    .font(.title3)
+                Text("Body")
+                    .font(.body)
+                Text("Callout")
+                    .font(.callout)
+                Text("Footnote")
+                    .font(.footnote)
+                Text("Caption 1")
+                    .font(.caption)
+                Text("Caption 2")
+                    .font(.caption2)
+            }
+            VStack {
+                Text("Large Title")
+                    .font(
+                        .custom(
+                            "Silkscreen-Regular",
+                            size: 34
+                        )
+                    )
+                Text("Title 1")
+                    .font(
+                        .custom(
+                            "Silkscreen-Regular",
+                            size: 28
+                        )
+                    )
+                Text("Title 2")
+                    .font(
+                        .custom(
+                            "Silkscreen-Regular",
+                            size: 22
+                        )
+                    )
+                Text("Title 3")
+                    .font(
+                        .custom(
+                            "Silkscreen-Regular",
+                            size: 20
+                        )
+                    )
+                Text("Body")
+                    .font(
+                        .custom(
+                            "Silkscreen-Regular",
+                            size: 17
+                        )
+                    )
+                Text("Callout")
+                    .font(
+                        .custom(
+                            "Silkscreen-Regular",
+                            size: 16
+                        )
+                    )
+                Text("Footnote")
+                    .font(
+                        .custom(
+                            "Silkscreen-Regular",
+                            size: 13
+                        )
+                    )
+                Text("Caption 1")
+                    .font(
+                        .custom(
+                            "Silkscreen-Regular",
+                            size: 12
+                        )
+                    )
+                Text("Caption 2")
+                    .font(
+                        .custom(
+                            "Silkscreen-Regular",
+                            size: 11
+                        )
+                    )
+            }
         }
     }
 }


### PR DESCRIPTION
### ブランチ
`feature/custom_font_cheatsheet`

### スクリーンショット
<img width="402" alt="Screenshot 2023-07-10 at 14 37 07" src="https://github.com/Masaya1582/SwiftUI_Playground/assets/74645651/1c5baa5c-fd28-437a-8df5-bebebff75421">
