### PR TITLE
ユーザがNavigationタイトルをいじれるようにする

### DIFF
--- a/SwiftUI_Playground/Sources/Views/HomeView.swift
+++ b/SwiftUI_Playground/Sources/Views/HomeView.swift
@@ -8,14 +8,15 @@
 import SwiftUI
 
 struct HomeView: View {
+    @State private var title = "Welcome"
+
     var body: some View {
-        VStack {
-            Text("Dio")
-                .font(.custom(FontFamily.Caprasimo.regular, size: 42))
-            Asset.Assets.imgDio.swiftUIImage
-                .resizable()
-                .frame(width: 320, height: 280)
-            Spacer().frame(height: 100)
+        NavigationStack {
+            Text("Hello, world!")
+                .font(.custom(FontFamily.Caprasimo.regular, size: 32))
+                .navigationTitle($title)
+                .navigationBarTitleDisplayMode(.inline)
+            // .toolbarRole(.editor)
         }
     }
 }


### PR DESCRIPTION
### ブランチ
`feature/custom_navigation`

### スクリーンショット
https://github.com/Masaya1582/SwiftUI_Playground/assets/74645651/84d2132c-55b2-49dd-84c1-0bdbc77e490f

