### PR TITLE
ユーザにColorPickerを使わせる

### DIFF
--- a/SwiftUI_Playground/Sources/Views/HomeView.swift
+++ b/SwiftUI_Playground/Sources/Views/HomeView.swift
@@ -8,15 +8,14 @@
 import SwiftUI
 
 struct HomeView: View {
+    @State private var bgColor = Color.white
+
     var body: some View {
         VStack {
-            Text("Dio")
-                .font(.custom(FontFamily.Caprasimo.regular, size: 42))
-            Asset.Assets.imgDio.swiftUIImage
-                .resizable()
-                .frame(width: 320, height: 280)
-            Spacer().frame(height: 100)
+            ColorPicker("Set the background color", selection: $bgColor)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(bgColor)
     }
 }
 


### PR DESCRIPTION
### ブランチ
`feature/colorpicker_usage`

### スクリーンショット
https://github.com/Masaya1582/SwiftUI_Playground/assets/74645651/e0de17b8-d1fb-4d8f-a402-34476146cb19

