### PR TITLE
過去の日付は選択出来ないカレンダー

### DIFF
--- a/SwiftUI_Playground/Sources/Views/HomeView.swift
+++ b/SwiftUI_Playground/Sources/Views/HomeView.swift
@@ -8,15 +8,21 @@
 import SwiftUI
 
 struct HomeView: View {
+    @Environment(\.calendar) var calendar
+    @State var dates: Set<DateComponents> = []
+
     var body: some View {
         VStack {
-            Text("Dio")
-                .font(.custom(FontFamily.Caprasimo.regular, size: 42))
-            Asset.Assets.imgDio.swiftUIImage
-                .resizable()
-                .frame(width: 320, height: 280)
-            Spacer().frame(height: 100)
+            MultiDatePicker("Select your preferred dates", selection: $dates, in: Date.now...)
+            Text(summary)
         }
+        .padding()
+    }
+
+    var summary: String {
+        dates.compactMap { components in
+            calendar.date(from: components)?.formatted(date: .long, time: .omitted)
+        }.formatted()
     }
 }
 


### PR DESCRIPTION
### ブランチ
`feature/multiple_date_with_currentdate`

### スクリーンショット
![Screenshot 2023-07-17 at 11 16 50](https://github.com/Masaya1582/SwiftUI_Playground/assets/74645651/29fce338-bec9-41a3-87fa-587a90d8b866)
