### PR TITLE
Navigationのバックボタンタイトルを消す

### DIFF
--- a/SwiftUI_Playground.xcodeproj/project.pbxproj
+++ b/SwiftUI_Playground.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1E54E7312A6A16C7002B10B0 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E54E7302A6A16C7002B10B0 /* DetailView.swift */; };
 		4011E8692A49759C003F06BF /* SwiftUI_PlaygroundApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4011E8682A49759C003F06BF /* SwiftUI_PlaygroundApp.swift */; };
 		4011E86B2A49759C003F06BF /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4011E86A2A49759C003F06BF /* HomeView.swift */; };
 		4011E86D2A49759D003F06BF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4011E86C2A49759D003F06BF /* Assets.xcassets */; };
@@ -24,6 +25,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1E54E7302A6A16C7002B10B0 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		3977D086BE021AF13A042E9A /* Pods_SwiftUI_Playground.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftUI_Playground.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4011E8652A49759C003F06BF /* SwiftUI_Playground.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUI_Playground.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4011E8682A49759C003F06BF /* SwiftUI_PlaygroundApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUI_PlaygroundApp.swift; sourceTree = "<group>"; };
@@ -136,6 +138,7 @@
 			isa = PBXGroup;
 			children = (
 				4011E86A2A49759C003F06BF /* HomeView.swift */,
+				1E54E7302A6A16C7002B10B0 /* DetailView.swift */,
 				40779B7B2A528D2800505ABD /* Modifiers */,
 			);
 			path = Views;
@@ -321,6 +324,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4011E88B2A4976DA003F06BF /* Fonts.swift in Sources */,
+				1E54E7312A6A16C7002B10B0 /* DetailView.swift in Sources */,
 				4011E86B2A49759C003F06BF /* HomeView.swift in Sources */,
 				40779B7D2A528D3200505ABD /* ButtonModifier.swift in Sources */,
 				4011E8892A4976D0003F06BF /* LocalizableStrings.swift in Sources */,

--- a/SwiftUI_Playground/Sources/Views/DetailView.swift
+++ b/SwiftUI_Playground/Sources/Views/DetailView.swift
@@ -1,0 +1,21 @@
+//
+//  DetailView.swift
+//  SwiftUI_Playground
+//
+//  Created by 中久木 雅哉(Nakakuki Masaya) on 2023/07/21.
+//  Copyright (c) 2023 ReNKCHANNEL. All rihgts reserved.
+//
+
+import SwiftUI
+
+struct DetailView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct DetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        DetailView()
+    }
+}

--- a/SwiftUI_Playground/Sources/Views/HomeView.swift
+++ b/SwiftUI_Playground/Sources/Views/HomeView.swift
@@ -11,19 +11,14 @@ struct HomeView: View {
     @ObservedObject var defaultViewModel = DefaultViewModel()
 
     var body: some View {
-        VStack {
-            Text("Dio")
-                .font(.custom(FontFamily.Caprasimo.regular, size: 42))
-            Asset.Assets.imgDio.swiftUIImage
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: 200, height: 200)
-                .clipShape(Circle())
-                .overlay(
-                    Circle()
-                        .stroke(Color.black, lineWidth: 2)
-                )
-            Spacer().frame(height: 100)
+        NavigationStack {
+            List {
+                NavigationLink("Detail") {
+                    DetailView()
+                        .toolbarRole(.editor)
+                }
+            }
+            .navigationTitle("Home")
         }
     }
 }


### PR DESCRIPTION
### ブランチ
`feature/remove_back_button`

### スクリーンショット
![Screenshot 2023-07-21 at 10 30 50](https://github.com/Masaya1582/SwiftUI_Playground/assets/74645651/7beb4791-cd1b-4710-bf49-d6fa2d85ec2d)
